### PR TITLE
Fixed specific replace implements bug

### DIFF
--- a/src/Compressor.php
+++ b/src/Compressor.php
@@ -1005,7 +1005,7 @@ class Compressor
 			$code = preg_replace( '/([^\\\a-z])'.$class_name.'::/i', '$1'.$full_class.'::', $code );
 						
 			// Replace class implements calls
-			$code = preg_replace( '/\s+implements(.*\W)'.$class_name.'/i', ' implements $1'.$full_class.' ', $code );
+            		$code = preg_replace( '/\s+implements(.*\W)'.$class_name.'([^\\\])/i', ' implements $1'.$full_class.'$2 ', $code );
 
 			// Handle instanceof operator
             		$code = preg_replace( '/instanceof\s+'.$class_name.'/i', 'instanceof '.$full_class.'', $code );


### PR DESCRIPTION
Fixed replaceing such namespaces \name\space\path1\className where path1 can be classNameAndSomeString and this case was replaced as \name\space\className AndSomeString\className
